### PR TITLE
Colour selector fallback bugfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gnome-gradienttopbar",
   "title": "Gradient Top Bar",
   "description": "Makes GNOME's topbar's background gradient.",
-  "version": "10",
+  "version": "11",
   "engines": {
     "gnome": ">=43"
   },

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,7 +5,7 @@
   "description": "Makes GNOME's topbar's background gradient. You can edit the colour scheme from the extension's settings.",
   "shell-version": ["43", "44"],
   "url": "https://github.com/petar-v/gradienttopbar",
-  "version": 10,
+  "version": 11,
   "gettext-domain": "org.pshow.gradienttopbar",
   "settings-schema": "org.gnome.shell.extensions.org.pshow.gradienttopbar",
   "hasPrefs": true

--- a/src/settings/components/colorDialog.js
+++ b/src/settings/components/colorDialog.js
@@ -1,7 +1,7 @@
 const { Adw, Gdk, Gio, GLib, GObject, Gtk } = imports.gi;
 
 const createColorDialogBtn = (pickerTitle, colroString, callback) => {
-  if ([Gtk.ColorDialog, Gtk.ColorDialogButton].includes(null)) {
+  if ([Gtk.ColorDialog, Gtk.ColorDialogButton].includes(undefined)) {
     return null;
   }
   const colorDialog = Gtk.ColorDialog.new();


### PR DESCRIPTION
# Purpose
This is addressing https://github.com/petar-v/gradienttopbar/issues/12 . The issue was that `Gtk.ColorDialog` should be checked for `undefined`, not `null`.

# Test file
[gradienttopbar@pshow.org.shell-extension.zip](https://github.com/petar-v/gradienttopbar/files/11638870/gradienttopbar%40pshow.org.shell-extension.zip)
