### PR TITLE
v22 release + dropped support for 45 and 46

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "gnome-gradienttopbar",
   "title": "Gradient Top Bar",
   "description": "Makes GNOME's panel's background gradient. You can edit the colour scheme from the extension's settings in Gnome 45.",
-  "version": "22-rc",
+  "version": "22",
   "engines": {
-    "gnome": ">=45"
+    "gnome": ">=47"
   },
   "shell-version": [
     "48"

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,7 @@
     "github": "petar-v",
     "paypal": "petarv73"
   },
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["47", "48"],
   "url": "https://github.com/petar-v/gradienttopbar",
   "version": 22,
   "gettext-domain": "org.pshow.gradienttopbar",


### PR DESCRIPTION
[gradienttopbar@pshow.org.shell-extension.zip](https://github.com/user-attachments/files/19670568/gradienttopbar%40pshow.org.shell-extension.zip)
