### PR TITLE
Add support for Gnome 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gnome-gradienttopbar",
   "title": "Gradient Top Bar",
   "description": "Give the top bar a customizable gradient. Choose direction and colors, and optionally use a different style or keep the theme when windows are maximized.",
-  "version": "23",
+  "version": "24",
   "engines": {
     "gnome": ">=49"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "gnome": ">=49"
   },
   "shell-version": [
-    "49"
+    "49",
+    "50"
   ],
   "uuid": "gradienttopbar@pshow.org",
   "url": "https://github.com/petar-v/gradienttopbar",

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,7 @@
     "github": "petar-v",
     "paypal": "petarv73"
   },
-  "shell-version": ["49"],
+  "shell-version": ["49", "50"],
   "url": "https://github.com/petar-v/gradienttopbar",
   "version": 23,
   "gettext-domain": "org.pshow.gradienttopbar",

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,7 +9,7 @@
   },
   "shell-version": ["49", "50"],
   "url": "https://github.com/petar-v/gradienttopbar",
-  "version": 23,
+  "version": 24,
   "gettext-domain": "org.pshow.gradienttopbar",
   "settings-schema": "org.gnome.shell.extensions.org.pshow.gradienttopbar",
   "hasPrefs": true


### PR DESCRIPTION
I added "50" in the supported versions and bumped version to 24. I tested it on Fedora 44 with Gnome 50.